### PR TITLE
Remove rustc-serialize feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ version = "0.2.0"
 bigint = ["num-bigint"]
 complex = ["num-complex"]
 rational = ["num-rational"]
-default = ["bigint", "num-bigint/rand", "complex", "rational", "rustc-serialize"]
+default = ["bigint", "num-bigint/rand", "complex", "rational"]
 
 rand = [
   "num-bigint/rand",
@@ -56,8 +56,4 @@ serde = [
   "num-bigint/serde",
   "num-complex/serde",
   "num-rational/serde"
-]
-rustc-serialize = [
-  "num-complex/rustc-serialize",
-  "num-rational/rustc-serialize"
 ]


### PR DESCRIPTION
0.2.0 doesn't have rustc-serialize support anymore

After this, patching should work:

```toml
[dependencies]
num = "0.2.0-git"

[patch.crates-io]
num = { git = "https://github.com/cuviper/num.git", branch = "release-0.2.0" }
```

It works currently with:

```toml
[patch.crates-io]
num = { git = "https://github.com/cad97/num.git", branch = "patch-1" }
```

Though I will be removing that branch as soon as this gets merged.